### PR TITLE
:green_heart: Modernize site build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,62 @@
 name: Build site
+
 on:
   push:
     branches:
       - "master"
+  pull_request:
+    branches:
+      - "master"
   repository_dispatch:
     types: [update]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
-  release:
+  build:
     name: Build
-    runs-on: ubuntu-18.04
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Build site
         run: npm run build
         env:
           NODE_ENV: "production"
-      - uses: maxheld83/ghpages@v0.2.1
-        name: GitHub Pages Deploy
-        env:
-          BUILD_DIR: "build/"
-          GH_PAT: ${{ secrets.GH_PAT }}
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-build
+          path: build/
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')) }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-build
+          path: build/
+      - name: GitHub Pages Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ github.token }}
+          publish_branch: gh-pages
+          publish_dir: ./build


### PR DESCRIPTION
## Summary
- Moves the site build workflow off the retired `ubuntu-18.04` runner.
- Adds PR/build validation for `master` and keeps deployment out of pull request runs.
- Replaces deprecated checkout/setup-node/gh-pages actions with current maintained actions and scopes write permission to the deploy job.

## Test Plan
- `python3` YAML parse for `.github/workflows/build.yml`
- `actionlint` via stdin for `.github/workflows/build.yml`
- `npx -y -p node@12 -p npm@6 npm ci`
- `npx -y -p node@12 -p npm@6 npm run build`
- Added-line security scan clean
- Independent Claude diff review passed
