### PR TITLE
:green_heart: Use Node 24 workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
     if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 12
           cache: npm
@@ -34,7 +34,7 @@ jobs:
         env:
           NODE_ENV: "production"
       - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: site-build
           path: build/
@@ -48,9 +48,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Download site artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: site-build
           path: build/


### PR DESCRIPTION
## Summary
- update checkout and setup-node to their Node 24-based v7 releases
- update artifact upload/download to their Node 24-based v7/v8 releases
- preserve the existing Node 12 site build and deploy behavior

The latest default-branch run warned that the v4 actions were deprecated and being forced onto Node 24 compatibility mode.

## Test plan
- [x] `npm ci` with Node 12.22.12 / npm 6.14.16
- [x] `npm run build`
- [x] workflow YAML parse
- [x] `actionlint`
- [x] verify each action tag's `action.yml` uses `node24` and retains the configured inputs
